### PR TITLE
Fix duplicate tree entry in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y \
     jq \
     tree \
     htop \
-    tree \
     && rm -rf /var/lib/apt/lists/*
 
 # 開発用ユーザーの作成（UID 1001を使用）


### PR DESCRIPTION
## Summary
- clean up package list in devcontainer Dockerfile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68489e4b15548329803c9cc6ebb906bd