### PR TITLE
Update README Python setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,11 @@ mise settings add idiomatic_version_file_enable_tools python
 
 ### 2. Pythonの依存関係のインストール
 
-pythonの依存関係のインストール
+Python の依存関係のインストールと仮想環境の有効化は
+`backend` ディレクトリで実行します。
 
 ```bash
 cd backend
 uv sync
-```
-
-pythonの仮想環境実行
-
-```bash
-. ./.venv/bin/activate
+. .venv/bin/activate
 ```


### PR DESCRIPTION
## Summary
- clarify that Python virtual environment activation occurs in the `backend` directory
- update example commands to show the correct relative path

## Testing
- `pre-commit run --files README.md` *(fails: pre-commit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489e5268fc832985270f358a5b07db